### PR TITLE
Fix missing import

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,3 +1,4 @@
+import os
 from sqlalchemy import create_engine, Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker


### PR DESCRIPTION
## Summary
- fix missing import for OS env var

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not fetch packages due to proxy)*


------
https://chatgpt.com/codex/tasks/task_e_684606c57610832aa3893a61c0285665